### PR TITLE
Set `max_retry_count=4` in `fetch_match_details`

### DIFF
--- a/django/api.py
+++ b/django/api.py
@@ -39,7 +39,7 @@ def _get_player_stat(stat_df, stat, steam_id):
     return stat_value
 
 
-def fetch_match_details(pmatch, max_retry_count=3):
+def fetch_match_details(pmatch, max_retry_count=4):
     for retry_idx in range(max_retry_count):
         time.sleep(retry_idx * 10)
         try:

--- a/django/tests/test_api.py
+++ b/django/tests/test_api.py
@@ -74,10 +74,10 @@ class fetch_match_details(unittest.TestCase):
 
             return raise_error
 
-        # Test ultimate failure (after 3 attempts)
-        mock_parse_demo.side_effect = raise_error_on_first_n_calls(3)
+        # Test ultimate failure (after 4 attempts)
+        mock_parse_demo.side_effect = raise_error_on_first_n_calls(4)
         self.assertRaises(api.InvalidDemoError, fetch_match_details)
-        self.assertEqual(mock_parse_demo.call_count, 3) # 3 invocations raising the error
+        self.assertEqual(mock_parse_demo.call_count, 4) # 4 invocations raising the error
 
         # Test success after two failures
         mock_parse_demo.call_count = 0


### PR DESCRIPTION
Increase max number of retries from 3 to `max_retry_count=4` in `fetch_match_details`.

There have been occasions in the logs, where `fetch_match_details` worked upon the 3rd retry. This is very likely due to demo files not yet been fully uploaded to the replay servers, so the downloads produce corrupted files. Adding a 4rth retry adds another 30 seconds of cooldown time, which should be sufficient for most demo files.