### PR TITLE
Fix bug with matches reported when session closes

### DIFF
--- a/django/stats/models.py
+++ b/django/stats/models.py
@@ -71,7 +71,11 @@ class GamingSession(models.Model):
 
         # Create a summary of the matches
         text = 'Matches played in this session:'
-        for pmatch in self.matches.order_by('timestamp').annotate(result = F('matchparticipation__result')):
+        for pmatch in self.matches.filter(
+            matchparticipation__player__in = self.squad.members.all()
+        ).distinct().order_by('timestamp').annotate(
+            result = F('matchparticipation__result')
+        ):
             text += f'\n- *{pmatch.map_name}*, **{pmatch.score_team1}:{pmatch.score_team2}** '
             text += dict(
                 w = 'won 🤘',


### PR DESCRIPTION
Fix bug introduced in #30. For only two played matches, many more matches have been reported:

> Matches played in this session:
> de_dust2, 14:16 lost 💩
> de_dust2, 14:16 lost 💩
> de_dust2, 14:16 lost 💩
> de_dust2, 14:16 lost 💩
> de_dust2, 14:16 lost 💩
> de_dust2, 14:16 won 🤘
> de_dust2, 14:16 won 🤘
> de_dust2, 14:16 won 🤘
> de_dust2, 14:16 won 🤘
> de_dust2, 14:16 won 🤘
> de_inferno, 4:13 lost 💩
> de_inferno, 4:13 lost 💩
> de_inferno, 4:13 lost 💩
> de_inferno, 4:13 lost 💩
> de_inferno, 4:13 lost 💩
> de_inferno, 4:13 won 🤘
> de_inferno, 4:13 won 🤘
> de_inferno, 4:13 won 🤘
> de_inferno, 4:13 won 🤘
> de_inferno, 4:13 won 🤘